### PR TITLE
Fixed problems when compiling xfce4-whiskermenu-plugin

### DIFF
--- a/libxfce4panel/libxfce4panel-1.0.pc.in
+++ b/libxfce4panel/libxfce4panel-1.0.pc.in
@@ -2,8 +2,8 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
-localedir=@localedir@
 datarootdir=@datarootdir@
+localedir=@localedir@
 api=1.0
 
 Name: libxfce4panel

--- a/libxfce4panel/libxfce4panel-2.0.pc.in
+++ b/libxfce4panel/libxfce4panel-2.0.pc.in
@@ -2,8 +2,8 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
-localedir=@localedir@
 datarootdir=@datarootdir@
+localedir=@localedir@
 api=@LIBXFCE4PANEL_VERSION_API@
 
 Name: libxfce4panel


### PR DESCRIPTION
in my case the pkgconfig file looks like this

```
# cat /usr/lib/x86_64-linux-gnu/pkgconfig/libxfce4panel-2.0.pc
prefix=/usr
exec_prefix=${prefix}
libdir=/usr/lib/x86_64-linux-gnu
includedir=${prefix}/include
localedir=${datarootdir}/locale
datarootdir=${prefix}/share
api=2.0

Name: libxfce4panel
Description: Library for the Xfce Panel
Requires: gtk+-3.0 gmodule-2.0 glib-2.0 libxfce4util-1.0
Version: 4.13.0git-17e74d4a
Libs: -L${libdir} -lxfce4panel-2.0
Cflags: -I${includedir}/xfce4/libxfce4panel-2.0
```

which causes problems and also looks like the wrong order...
it caused
```
Variable 'datarootdir' not defined in [...]
```