### PR TITLE
Allow autohide style to be slide(animated) or collapse(instant)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,7 +4,7 @@
  - Drop Gtk2/4.6-only references from the docs
  - Don't show or try to load Gtk2 plugins anymore
  - Add dark mode preference
- - autohide: Add sliding out animation
+ - autohide: Add optional sliding out animation
  - Draw panel border based on position and length
  - appmenu: Listen to icon theme changes (Bug #15861)
  - appmenu: Use panel's icon size

--- a/panel/panel-application.c
+++ b/panel/panel-application.c
@@ -288,6 +288,7 @@ panel_application_xfconf_window_bindings (PanelApplication *application,
   {
     { "position-locked", G_TYPE_BOOLEAN },
     { "autohide-behavior", G_TYPE_UINT },
+    { "autohide-style", G_TYPE_UINT },
     { "span-monitors", G_TYPE_BOOLEAN },
     { "mode", G_TYPE_UINT },
     { "size", G_TYPE_UINT },

--- a/panel/panel-preferences-dialog.c
+++ b/panel/panel-preferences-dialog.c
@@ -476,6 +476,7 @@ panel_preferences_dialog_bindings_update (PanelPreferencesDialog *dialog)
   panel_preferences_dialog_bindings_add (dialog, "span-monitors", "active", 0);
   panel_preferences_dialog_bindings_add (dialog, "position-locked", "active", 0);
   panel_preferences_dialog_bindings_add (dialog, "autohide-behavior", "active", 0);
+  panel_preferences_dialog_bindings_add (dialog, "autohide-style", "active", 0);
   panel_preferences_dialog_bindings_add (dialog, "disable-struts", "active", 0);
   panel_preferences_dialog_bindings_add (dialog, "size", "value", 0);
   panel_preferences_dialog_bindings_add (dialog, "nrows", "value", 0);
@@ -667,6 +668,7 @@ panel_preferences_dialog_autohide_changed (GtkComboBox            *combobox,
                                            PanelPreferencesDialog *dialog)
 {
   GObject *object;
+  GObject *styleobj;
 
   panel_return_if_fail (GTK_IS_COMBO_BOX (combobox));
   panel_return_if_fail (PANEL_IS_PREFERENCES_DIALOG (dialog));
@@ -675,11 +677,22 @@ panel_preferences_dialog_autohide_changed (GtkComboBox            *combobox,
   object = gtk_builder_get_object (GTK_BUILDER (dialog), "disable-struts");
   panel_return_if_fail (GTK_IS_WIDGET (object));
 
-  /* make "don't reserve space on borders" sensitive only when autohide is disabled */
+  styleobj = gtk_builder_get_object (GTK_BUILDER (dialog), "autohide-style");
+  panel_return_if_fail (GTK_IS_COMBO_BOX (styleobj));
+
+  /* make "don't reserve space on borders" sensitive only when autohide is disabled,
+   * and vice versa for auto hide style
+   */
   if (gtk_combo_box_get_active (combobox) == 0)
-    gtk_widget_set_sensitive (GTK_WIDGET (object), TRUE);
+    {
+      gtk_widget_set_sensitive (GTK_WIDGET (object), TRUE);
+      gtk_widget_set_sensitive (GTK_WIDGET (styleobj), FALSE);
+    }
   else
-    gtk_widget_set_sensitive (GTK_WIDGET (object), FALSE);
+    {
+      gtk_widget_set_sensitive (GTK_WIDGET (object), FALSE);
+      gtk_widget_set_sensitive (GTK_WIDGET (styleobj), TRUE);
+    }
 }
 
 

--- a/panel/panel-preferences-dialog.glade
+++ b/panel/panel-preferences-dialog.glade
@@ -20,6 +20,20 @@
       </row>
     </data>
   </object>
+  <object class="GtkListStore" id="autohide-style-store">
+    <columns>
+      <!-- column-name title -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">Slide</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Collapse</col>
+      </row>
+    </data>
+  </object>
   <object class="GtkSizeGroup" id="bg-sizegroup"/>
   <object class="GtkSizeGroup" id="display-sizegroup"/>
   <object class="GtkAdjustment" id="enter-opacity">
@@ -443,7 +457,7 @@
                           </object>
                           <packing>
                             <property name="left_attach">0</property>
-                            <property name="top_attach">6</property>
+                            <property name="top_attach">7</property>
                             <property name="width">2</property>
                           </packing>
                         </child>
@@ -522,6 +536,51 @@
                           <packing>
                             <property name="left_attach">1</property>
                             <property name="top_attach">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="spacing">12</property>
+                            <child>
+                              <object class="GtkLabel" id="autohidestyle_label">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Panel-hiding style: </property>
+                                <property name="use_underline">True</property>
+                                <property name="xalign">0</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkComboBox" id="autohide-style">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="model">autohide-style-store</property>
+                                <child>
+                                  <object class="GtkCellRendererText" id="cellrenderertext6"/>
+                                  <attributes>
+                                    <attribute name="text">0</attribute>
+                                  </attributes>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="pack_type">end</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">6</property>
+                            <property name="width">2</property>
                           </packing>
                         </child>
                       </object>


### PR DESCRIPTION
xfce4-panel recently added a slide animation to hiding the panel. However, this animation seems to interact poorly with the fluxbox window manager, which I use instead of xfwm4, leading to a cascade of X events which brings my X server to its knees. This pull request adds a configuration choice in the panel preferences to select either the new slide behavior (the default) or the old instant collapse behavior. With my panels set to collapse, I find the destructive interaction with fluxbox to be eliminated.

I am aware that xfce4 maintainers may not monitor this repository and will also post an issue on bugzilla.