### PR TITLE
fix plugin restart prompt removing the plugin when disregarding the dialog

### DIFF
--- a/panel/panel-plugin-external.c
+++ b/panel/panel-plugin-external.c
@@ -406,14 +406,14 @@ panel_plugin_external_child_ask_restart_dialog (GtkWindow   *parent,
                                             "the plugin otherwise it will be permanently removed from the panel."),
                                             PANEL_PLUGIN_AUTO_RESTART);
   gtk_dialog_add_buttons (GTK_DIALOG (dialog), _("_Execute"), GTK_RESPONSE_OK,
-                          _("_Remove"), GTK_RESPONSE_CLOSE, NULL);
+                          _("_Remove"), GTK_RESPONSE_REJECT, NULL);
   gtk_dialog_set_default_response (GTK_DIALOG (dialog), GTK_RESPONSE_OK);
   gtk_window_set_position (GTK_WINDOW (dialog), GTK_WIN_POS_CENTER);
 
   response = gtk_dialog_run (GTK_DIALOG (dialog));
   gtk_widget_destroy (dialog);
 
-  return (response == GTK_RESPONSE_OK);
+  return (response != GTK_RESPONSE_REJECT);
 }
 
 


### PR DESCRIPTION
> Previously when prompted to either restart or permanently remove a plugin from the panel, hitting escape (ESC) on the keyboard to close the sudden popup dialog would choose the destructive action. This patch changes it to the harmless one: restarting the plugin.

The current behavior has caught me off guard several times, causing me to nuke the `xfce4-docklike-plugin` with its configuration.

Full disclosure: I did not build or test this patch. My system is currently too old to do so. I hope to have this change after upgrading in the not too distant future though. :wink:
Would you be so kind and test it for me, or maybe its even a simple enough change to not need any testing?